### PR TITLE
Raising the right error when wrong charcode is used

### DIFF
--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -168,7 +168,7 @@ class Escpos:
         elif code.upper() == "THAI18":
             self._raw(CHARCODE_THAI18)
         else:
-            raise CharCode_error()
+            raise CharCodeError()
 
     def barcode(self, code, bc, width, height, pos, font):
         """ Print Barcode """


### PR DESCRIPTION
CharCode_error no longer exists and it throws a not defined error when you actually try to raise that exception.
Changing this to CharCodeError seems to fix the problem :)