### PR TITLE
Extended params for serial printers

### DIFF
--- a/escpos/printer.py
+++ b/escpos/printer.py
@@ -69,23 +69,39 @@ class Usb(Escpos):
 class Serial(Escpos):
     """ Define Serial printer """
 
-    def __init__(self, devfile="/dev/ttyS0", baudrate=9600, bytesize=8, timeout=1):
+    def __init__(self, devfile="/dev/ttyS0", baudrate=9600, bytesize=8, timeout=1,
+                 parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
+                 xonxoff=False , dsrdtr=True):
         """
         @param devfile  : Device file under dev filesystem
         @param baudrate : Baud rate for serial transmission
         @param bytesize : Serial buffer size
         @param timeout  : Read/Write timeout
+        
+        @param parity   : Parity checking
+        @param stopbits : Number of stop bits
+        @param xonxoff  : Software flow control
+        @param dsrdtr   : Hardware flow control (False to enable RTS/CTS)
         """
         self.devfile  = devfile
         self.baudrate = baudrate
         self.bytesize = bytesize
         self.timeout  = timeout
+        
+        self.parity = parity
+        self.stopbits = stopbits
+        self.xonxoff = xonxoff
+        self.dsrdtr = dsrdtr
+        
         self.open()
 
 
     def open(self):
         """ Setup serial port and set is as escpos device """
-        self.device = serial.Serial(port=self.devfile, baudrate=self.baudrate, bytesize=self.bytesize, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=self.timeout, dsrdtr=True)
+        self.device = serial.Serial(port=self.devfile, baudrate=self.baudrate,
+                                    bytesize=self.bytesize, parity=self.parity,
+                                    stopbits=self.stopbits, timeout=self.timeout,
+                                    xonxoff=self.xonxoff, dsrdtr=self.dsrdtr)
 
         if self.device is not None:
             print "Serial printer enabled"


### PR DESCRIPTION
Updated printer.Serial() constructor and its open() method to extend serial params.
Backwards compatible, no client modifications needed.