### PR TITLE
Support for images vertically longer than 256 pixels

### DIFF
--- a/escpos/escpos.py
+++ b/escpos/escpos.py
@@ -41,7 +41,7 @@ class Escpos:
         buffer = ""
        
         self._raw(S_RASTER_N)
-        buffer = "%02X%02X%02X%02X" % (((size[0]/size[1])/8), 0, size[1], 0)
+        buffer = "%02X%02X%02X%02X" % (((size[0]/size[1])/8), 0, size[1]&0xff, size[1]>>8)
         self._raw(buffer.decode('hex'))
         buffer = ""
 
@@ -68,7 +68,7 @@ class Escpos:
 
         if im.size[0] > 512:
             print  ("WARNING: Image is wider than 512 and could be truncated at print time ")
-        if im.size[1] > 255:
+        if im.size[1] > 0xffff:
             raise ImageSizeError()
 
         im_border = self._check_image_size(im.size[0])


### PR DESCRIPTION
Fixes issue #31. Tested on Cashino CSN-A3 thermal printer.

Please note that this allows sending huge amounts of data to thermal printer and if you are not using flow control then serial buffers on your printer go nuts and printing gets messy at some point. If you enable CTS/RTS or XON/XOFF then there is no problem at all!

PS. I wrote this patch last February but because you were hosting at Google Code it was not worth the hassle to send it. But since you are on GitHub now and still have that issue, here you are! :-)