### PR TITLE
Prevent crash when using libusb0 printers

### DIFF
--- a/escpos/printer.py
+++ b/escpos/printer.py
@@ -40,11 +40,19 @@ class Usb(Escpos):
         if self.device is None:
             print "Cable isn't plugged in"
 
-        if self.device.is_kernel_driver_active(0):
+        check_driver = None
+
+        try:
+            check_driver = self.device.is_kernel_driver_active(0)
+        except NotImplementedError:
+            pass
+
+        if check_driver is None or check_driver:
             try:
                 self.device.detach_kernel_driver(0)
             except usb.core.USBError as e:
-                print "Could not detatch kernel driver: %s" % str(e)
+                if check_driver is not None:
+                    print "Could not detatch kernel driver: %s" % str(e)
 
         try:
             self.device.set_configuration()


### PR DESCRIPTION
libusb0 printers do not have the is_kernel_driver_active method. This patch detects if that method is missing, and if so attempts to detach the kernel driver anyway, ignoring the error if it turns out that the kernel driver is not attached.